### PR TITLE
Feat : 병원 메인홈 목데이터 연결

### DIFF
--- a/public/data/applications.json
+++ b/public/data/applications.json
@@ -1,0 +1,123 @@
+{
+  "default": [
+    {
+      "applicantId": "1",
+      "applicantName": "박연진",
+      "applicantEmail": "yeon@naver.com",
+      "applicantBirthdate": "1990-08-08",
+      "applicantGender": "여자",
+      "applicantContact": "010-1111-1111",
+      "applicantFilePath": "./박연진.pdf",
+      "applicantEducation": "고졸",
+      "applicantWorkExperience": "신입",
+      "applicantSector": "간호조무사",
+      "jobpostID": "1",
+      "jobpostTitle": " 간호조무사 신입 채용",
+      "applicationId": "1",
+      "applicationStatusType": "default",
+      "applyDate": "2023-03-30",
+      "memo": "서류검토중"
+    },
+    {
+      "applicantId": "2",
+      "applicantName": "문동은",
+      "applicantEmail": "moon88@naver.com",
+      "applicantBirthdate": "1988-02-02",
+      "applicantGender": "여자",
+      "applicantContact": "010-1341-4511",
+      "applicantFilePath": "./문동은.pdf",
+      "applicantEducation": "초대졸",
+      "applicantWorkExperience": "3년차",
+      "applicantSector": "간호조무사",
+      "jobpostID": "1",
+      "jobpostTitle": " 간호조무사 채용",
+      "applicationId": "2",
+      "applicationStatusType": "default",
+      "applyDate": "2023-03-28",
+      "interviewDate": null,
+      "memo": "개인병원 경력 있음. 서류통과 검토중"
+    },
+    {
+      "applicantId": "3",
+      "applicantName": "이사라",
+      "applicantEmail": "saraa@naver.com",
+      "applicantBirthdate": "1995-08-02",
+      "applicantGender": "여자",
+      "applicantContact": "010-3434-2323",
+      "applicantFilePath": "./이사라.pdf",
+      "applicantEducation": "대졸",
+      "applicantWorkExperience": "신입",
+      "applicantSector": "간호조무사",
+      "jobpostID": "1",
+      "jobpostTitle": " 간호조무사 채용",
+      "applicationId": "3",
+      "applicationStatusType": "default",
+      "applyDate": "2023-03-30",
+      "interviewDate": null,
+      "memo": "경력이 없어서,,"
+    }
+  ],
+  "resume-pass": [
+    {
+      "applicantId": "4",
+      "applicantName": "전재준",
+      "applicantEmail": "jjj123@naver.com",
+      "applicantBirthdate": "1993-07-13",
+      "applicantGender": "남자",
+      "applicantContact": "010-3334-2323",
+      "applicantFilePath": "./전재준.pdf",
+      "applicantEducation": "대졸",
+      "applicantWorkExperience": "4년차",
+      "applicantSector": "간호조무사",
+      "jobpostID": "1",
+      "jobpostTitle": " 간호조무사 채용",
+      "applicationId": "4",
+      "applicationStatusType": "resume-pass",
+      "applyDate": "2023-03-20",
+      "interviewDate": null,
+      "memo": "면접날짜 고민중"
+    }
+  ],
+  "interview": [
+    {
+      "applicantId": "5",
+      "applicantName": "이지원",
+      "applicantEmail": "zwon123@naver.com",
+      "applicantBirthdate": "1992-08-23",
+      "applicantGender": "여자",
+      "applicantContact": "010-3334-2323",
+      "applicantFilePath": "./이지원.pdf",
+      "applicantEducation": "대졸",
+      "applicantWorkExperience": "2년차",
+      "applicantSector": "간호조무사",
+      "jobpostID": "1",
+      "jobpostTitle": " 간호조무사 채용",
+      "applicationId": "5",
+      "applicationStatusType": "interview",
+      "applyDate": "2023-03-23",
+      "interviewDate": "2023-04-10",
+      "memo": "면접때 뭐물어보쥐..."
+    }
+  ],
+  "interview-pass": [
+    {
+      "applicantId": "6",
+      "applicantName": "손명오",
+      "applicantEmail": "son13@naver.com",
+      "applicantBirthdate": "1988-02-20",
+      "applicantGender": "남자",
+      "applicantContact": "010-3334-2323",
+      "applicantFilePath": "./이지원.pdf",
+      "applicantEducation": "대졸",
+      "applicantWorkExperience": "2년차",
+      "applicantSector": "간호조무사",
+      "jobpostID": "1",
+      "jobpostTitle": " 간호조무사 채용",
+      "applicationId": "6",
+      "applicationStatusType": "interview",
+      "applyDate": "2023-03-23",
+      "interviewDate": "2023-04-01",
+      "memo": "5월1일 입사예정"
+    }
+  ]
+}

--- a/src/@types/data.d.ts
+++ b/src/@types/data.d.ts
@@ -78,3 +78,31 @@ interface IScheduleData {
 interface Props {
   fileUrl: string | undefined;
 }
+
+interface CompanyMainData {
+  applicantId: string;
+  applicantName: string;
+  applicantEmail: string;
+  applicantBirthdate: string;
+  applicantGender: string;
+  applicantContact: string;
+  applicantFilePath: string;
+  applicantEducation: string;
+  applicantWorkExperience: string;
+  applicantSector: string;
+  jobpostID: string;
+  jobpostTitle: string;
+  applicationId: string;
+  applicationStatusType: string;
+  applyDate: string;
+  interviewDate: string;
+  memo: string;
+}
+
+interface mailTypeCase {
+  기본: 기본;
+  서류합격: 서류합격;
+  서류불합격: 서류불합격;
+  면접합격: 면접합격;
+  면접불합격: 면접불합격;
+}

--- a/src/@types/props.d.ts
+++ b/src/@types/props.d.ts
@@ -74,6 +74,7 @@ export interface IStepBoxProps {
   stepName: string;
   step: string;
   setStep: React.Dispatch<React.SetStateAction<string>>;
+  num: number;
 }
 
 export interface IPostingContensProps {

--- a/src/api/companyApi.ts
+++ b/src/api/companyApi.ts
@@ -1,8 +1,11 @@
+import axios from 'axios';
 import { instance } from './instance';
 
 export const getApplications = async () => {
   try {
-    const res = await instance.get(`/company/applications`);
+    const res = await fetch('http://127.0.0.1:5173/data/applications.json');
+    const data = await res.json();
+    return data;
   } catch (error) {
     console.log(error);
   }

--- a/src/components/companyApplicant/ApplicantsList.tsx
+++ b/src/components/companyApplicant/ApplicantsList.tsx
@@ -32,7 +32,9 @@ const ApplicantsList = ({ item }: { item: any }) => {
           </button>
         </div>
       </Inner>
-      {emailModal ? <EmailModal setEmailModal={setEmailModal} /> : null}
+      {emailModal ? (
+        <EmailModal setEmailModal={setEmailModal} email={'email@email.com'} applicantName={'이름'} mailType={'기본'} />
+      ) : null}
       {open ? (
         <HideContent>
           <Resume>이력서</Resume>

--- a/src/components/mainhome/ApplicantList.tsx
+++ b/src/components/mainhome/ApplicantList.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import EmailModal from './EmailModal';
 import ConfirmModal from '../common/ConfirmModal';
 import { getDday } from '@/utils/getDday';
+import AlertModal from '../common/AlertModal';
 
 const ApplicantList = ({ index, step, applicant }: { index: number; step: string; applicant: CompanyMainData }) => {
   const [open, setOpen] = useState(index === 0 ? true : false);
@@ -90,7 +91,7 @@ const ApplicantList = ({ index, step, applicant }: { index: number; step: string
                   {step === '서류통과' ? (
                     <button onClick={() => {}}>면접일정확정</button>
                   ) : step === '최종합격' ? (
-                    <button onClick={() => {}}>채용확정</button>
+                    ''
                   ) : (
                     <>
                       <button
@@ -177,9 +178,9 @@ const ListComponent = styled.div`
   }
 `;
 
-const Head = styled.div`
+const Head = styled.div<{ open: boolean }>`
   width: 100%;
-  height: ${({ open }: { open: boolean }) => {
+  height: ${({ open }) => {
     return open ? '460px' : '70px';
   }};
   box-shadow: 2px 2px 10px 2px #4357ac26;
@@ -187,11 +188,11 @@ const Head = styled.div`
   border-radius: 20px;
   margin: 0 auto;
   display: flex;
-  align-items: ${({ open }: { open: boolean }) => {
+  align-items: ${({ open }) => {
     return open ? 'flex-start' : 'center';
   }};
   justify-content: space-between;
-  padding: ${({ open }: { open: boolean }) => {
+  padding: ${({ open }) => {
     return open ? '15px 40px' : '0 40px';
   }};
   margin-bottom: 20px;

--- a/src/components/mainhome/ApplicantList.tsx
+++ b/src/components/mainhome/ApplicantList.tsx
@@ -2,40 +2,74 @@ import Avvvatars from 'avvvatars-react';
 import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import EmailModal from './EmailModal';
+import ConfirmModal from '../common/ConfirmModal';
+import { getDday } from '@/utils/getDday';
 
-const ApplicantList = ({ index, step }: { index: number; step: string }) => {
+const ApplicantList = ({ index, step, applicant }: { index: number; step: string; applicant: CompanyMainData }) => {
   const [open, setOpen] = useState(index === 0 ? true : false);
   const [emailModal, setEmailModal] = useState(false);
+  const [mailType, setMailType] = useState<keyof mailTypeCase>('서류합격');
+  const {
+    applicantId,
+    applicantName,
+    applicantEmail,
+    applicantBirthdate,
+    applicantGender,
+    applicantContact,
+    applicantFilePath,
+    applicantEducation,
+    applicantWorkExperience,
+    applicantSector,
+    jobpostID,
+    jobpostTitle,
+    applicationId,
+    applicationStatusType,
+    applyDate,
+    interviewDate,
+    memo,
+  } = applicant;
 
   return (
     <ListComponent>
       <Head onClick={() => setOpen(!open)} open={open}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px', height: '32px' }}>
-          <Avvvatars value={'조지원'} style='shape'></Avvvatars>
-          <p className='name'>조지원</p>
+          <Avvvatars value={applicantName} style='shape'></Avvvatars>
+          <p className='name'>{applicantName}</p>
           {open ? null : (
             <>
-              <div className='sector'>간호사</div>
-              <div className='tag'># 대졸</div>
-              <div className='tag'># 1년 경력</div>
+              <div className='sector'>{applicantSector}</div>
+              <div className='tag'># {applicantEducation}</div>
+              <div className='tag'># {applicantWorkExperience}</div>
             </>
           )}
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-          <p className='applyDate'>23.04.10</p>
-          <div className='dDay'>지원 D+5</div>
+          <p className='applyDate'>{applyDate}</p>
+          <div className='dDay'>
+            {step === '서류지원' || step === '서류통과' ? '지원' : '면접'} D
+            {step === '서류지원' || step === '서류통과' ? `${getDday(applyDate)}` : getDday(interviewDate)}
+          </div>
           <img
             src='/icons/email.png'
             alt='이메일'
             className='email'
             onClick={event => {
               event.stopPropagation();
+              setMailType('기본');
               setEmailModal(true);
             }}
           />
         </div>
       </Head>
-      {emailModal ? <EmailModal setEmailModal={setEmailModal} /> : null}
+      {emailModal ? (
+        <EmailModal
+          setEmailModal={setEmailModal}
+          email={applicantEmail}
+          applicantName={applicantName}
+          mailType={mailType}
+          jobpostTitle={jobpostTitle}
+        />
+      ) : null}
       <Body>
         {open ? (
           <>
@@ -44,21 +78,67 @@ const ApplicantList = ({ index, step }: { index: number; step: string }) => {
               <div style={{ width: '210px', height: '297px', backgroundColor: '#ECECEC' }}>이력서</div>
               <div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '10px', height: '32px' }}>
-                  <div className='sector'>간호사</div>
-                  <div className='tag'># 대졸</div>
-                  <div className='tag'># 1년 경력</div>
+                  <div className='sector'>{applicantSector}</div>
+                  <div className='tag'># {applicantEducation}</div>
+                  <div className='tag'># {applicantWorkExperience}</div>
                 </div>
                 <p>메모</p>
-                <textarea name='memo' id='memo' cols={30} rows={10}></textarea>
+                <textarea name='memo' id='memo' cols={30} rows={10}>
+                  {memo}
+                </textarea>
                 <div className='buttons'>
                   {step === '서류통과' ? (
-                    <button>면접제안</button>
-                  ) : step === '채용제안' ? (
-                    <button>채용안내</button>
+                    <button onClick={() => {}}>면접일정확정</button>
+                  ) : step === '최종합격' ? (
+                    <button onClick={() => {}}>채용확정</button>
                   ) : (
                     <>
-                      <button>합격</button>
-                      <button>불합격</button>
+                      <button
+                        onClick={() => {
+                          if (step === '서류지원') {
+                            ConfirmModal({
+                              message: '서류합격 메일 전송화면으로 이동합니다.',
+                              action: () => {
+                                setMailType('서류합격');
+                                setEmailModal(true);
+                              },
+                            });
+                          } else {
+                            ConfirmModal({
+                              message: '면접합격 메일 전송화면으로 이동합니다.',
+                              action: () => {
+                                setMailType('면접합격');
+                                setEmailModal(true);
+                              },
+                            });
+                          }
+                        }}
+                      >
+                        합격
+                      </button>
+                      <button
+                        onClick={() => {
+                          if (step === '서류지원') {
+                            ConfirmModal({
+                              message: '서류불합격 메일 전송화면으로 이동합니다.',
+                              action: () => {
+                                setMailType('서류불합격');
+                                setEmailModal(true);
+                              },
+                            });
+                          } else {
+                            ConfirmModal({
+                              message: '면접불합격 메일 전송화면으로 이동합니다.',
+                              action: () => {
+                                setMailType('면접불합격');
+                                setEmailModal(true);
+                              },
+                            });
+                          }
+                        }}
+                      >
+                        불합격
+                      </button>
                     </>
                   )}
                 </div>

--- a/src/components/mainhome/EmailModal.tsx
+++ b/src/components/mainhome/EmailModal.tsx
@@ -15,10 +15,10 @@ const EmailModal = ({
   email: string;
   applicantName: string;
   mailType: keyof mailTypeCase;
-  jobpostTitle: string;
+  jobpostTitle?: string;
 }) => {
   const QuillRef = useRef<ReactQuill>();
-  const [contents, setContents] = useState(getMailSample({ applicantName, mailType, jobpostTitle }));
+  const [contents, setContents] = useState(getMailSample({ applicantName, mailType, jobpostTitle: '' }));
   const [receiver, setReceiver] = useState('');
   const [title, setTitle] = useState('');
 
@@ -28,7 +28,11 @@ const EmailModal = ({
 
   useEffect(() => {
     setReceiver(`${applicantName}, ${email}`);
-    setTitle(`${jobpostTitle}관련 안내`);
+    if (jobpostTitle) {
+      setTitle(`${jobpostTitle}관련 안내`);
+    } else {
+      setTitle('');
+    }
     // setContents(getMailSample({ applicantName, mailType, jobpostTitle }));
   });
 

--- a/src/components/mainhome/EmailModal.tsx
+++ b/src/components/mainhome/EmailModal.tsx
@@ -1,32 +1,58 @@
-import React, { SetStateAction, useRef, useState } from 'react';
+import React, { SetStateAction, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import WebEditor from '@components/common/WebEditor';
 import ReactQuill from 'react-quill';
+import { getMailSample } from '@/constants/mailSample';
 
-const EmailModal = ({ setEmailModal }: { setEmailModal: React.Dispatch<React.SetStateAction<boolean>> }) => {
+const EmailModal = ({
+  setEmailModal,
+  email,
+  applicantName,
+  mailType,
+  jobpostTitle,
+}: {
+  setEmailModal: React.Dispatch<React.SetStateAction<boolean>>;
+  email: string;
+  applicantName: string;
+  mailType: keyof mailTypeCase;
+  jobpostTitle: string;
+}) => {
   const QuillRef = useRef<ReactQuill>();
-  const [contents, setContents] = useState('');
+  const [contents, setContents] = useState(getMailSample({ applicantName, mailType, jobpostTitle }));
+  const [receiver, setReceiver] = useState('');
+  const [title, setTitle] = useState('');
 
   const sendEmail = () => {
-    console.log(contents);
+    console.log(contents, email);
   };
+
+  useEffect(() => {
+    setReceiver(`${applicantName}, ${email}`);
+    setTitle(`${jobpostTitle}관련 안내`);
+    // setContents(getMailSample({ applicantName, mailType, jobpostTitle }));
+  });
 
   return (
     <ModalBackground>
       <div id='container'>
         <header>
-          <h3>안내 이메일 전송</h3>
+          <h3>{mailType} 이메일 전송</h3>
           <img src='/icons/close.png' alt='닫기' onClick={() => setEmailModal(false)} />
         </header>
         <div id='content'>
           <form>
             <div className='space-between'>
               <label htmlFor='emailAddress'>받는 사람</label>
-              <input type='text' id='emailAddress' />
+              <input
+                type='text'
+                id='emailAddress'
+                value={receiver}
+                onChange={event => setReceiver(event.target.value)}
+              />
             </div>
             <div className='space-between'>
               <label htmlFor='title'>제목</label>
-              <input type='text' id='title' />
+              <input type='text' id='title' value={title} onChange={event => setTitle(event.target.value)} />
             </div>
             <WebEditor QuillRef={QuillRef} contents={contents} setContents={setContents}></WebEditor>
           </form>

--- a/src/components/mainhome/StepBox.tsx
+++ b/src/components/mainhome/StepBox.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { IStepBoxProps } from '../../@types/props';
 
-const StepBox = ({ stepName, step, setStep }: IStepBoxProps) => {
+const StepBox = ({ stepName, step, setStep, num }: IStepBoxProps) => {
   const type = useLocation().pathname.split('/')[1];
 
   return (
@@ -13,7 +13,7 @@ const StepBox = ({ stepName, step, setStep }: IStepBoxProps) => {
       onClick={() => setStep(stepName)}
     >
       <h3>{stepName}</h3>
-      <p>10</p>
+      <p>{num}</p>
     </div>
   );
 };

--- a/src/constants/mailSample.ts
+++ b/src/constants/mailSample.ts
@@ -1,3 +1,5 @@
+import { getCookie } from '@/utils/cookie';
+
 let str = `
   안녕하세요, [ 지원자 이름 ] 님.
 
@@ -29,3 +31,68 @@ export const mailSample = [
   { title: '[SAMPLE] 서류 탈락 문자 양식', content: str },
   { title: '[SAMPLE] 서류 통과 문자 양식', content: str2 },
 ];
+
+export const getMailSample = ({
+  applicantName,
+  mailType,
+  jobpostTitle,
+}: {
+  applicantName: string;
+  mailType: keyof mailTypeCase;
+  jobpostTitle: string;
+}) => {
+  const companyName = getCookie('companyName') || '메디매치';
+
+  switch (mailType) {
+    case '기본':
+      return ``;
+    case '서류합격':
+      return `
+      <p>안녕하세요, ${applicantName}님.</p>
+      <p><br></p>
+      <p>${companyName}의 ${jobpostTitle} 전형에 관심 갖고, 지원해주셔서 감사드립니다.</p>
+      <p>${applicantName} 께서 정성스럽게 작성해주신 이력서를 보니, 꼭 만나뵙고 싶다는 생각이 들었습니다.</p>
+      <p><br></p>
+      <p>면접 안내 사항 정리하여 전달 드립니다.</p>
+      <p>- 면접 일시 :</p>
+      <p>- 면접 장소 :</p>
+      <p>- 소요 시간 :</p>
+      <p><br></p>
+      <p>궁금한 사항은 본 메일을 통해 문의 바랍니다. 감사합니다.</p>`;
+    case '서류불합격':
+      return `
+      <p>안녕하세요, ${applicantName}님. </p><p><br></p><p>${companyName}의 ${jobpostTitle} 전형에 지원해주셔서 진심으로 감사합니다. </p><p><br></p><p>보내주신 서류들을 검토한 결과 안타깝게도 ${applicantName}님이 탈락하게 되었습니다. </p><p><br></p><p>우리 병원과 함께 할 가능성을 보여주신 것에 대해 다시 한번 감사드립니다.</p>`;
+    case '면접합격':
+      return `
+      <p>안녕하세요, ${applicantName}님.</p>
+      <p><br></p>
+      <p>${companyName}의 ${jobpostTitle} 전형에 관심 갖고, 지원해주셔서 감사드립니다.</p>
+      <p>${applicantName}님이 보유하신 역량과 경험들이 저희 병원에 큰 도움이 될 것 같아 아래와 같이 제안 드립니다.</p>
+      <p><br></p>
+      <p>입사시 처우</p>
+      <p>- 포지션 :</p>
+      <p>- 계약 연봉 :</p>
+      <p>- 근무 형태 :</p>
+      <p>- 입사일 :</p>
+      <p><br></p>
+      <p>저희 ${companyName}에서 ${applicantName}님과 함께, 즐겁게 일할 수 있기를 기대합니다.</p>
+      <p><br></p>
+      <p>제안 사항 확인 후 회신 부탁드립니다.</p>
+      <p>궁금한 사항이 있으시면 편하게 연락주세요. 감사합니다.</p>`;
+    case '면접불합격':
+      return `
+      <p>안녕하세요, ${applicantName}님.</p>
+      <p><br></p>
+      <p>${companyName}의 ${jobpostTitle} 전형에 관심 갖고, 지원해주셔서 감사드립니다.</p>
+      <p><br></p>
+      <p>${applicantName} 님께서 그간 걸어온 길을 꼼꼼히 검토해보았습니다만, 아쉽게도 이번에는 합격 소식을 전해드리지 못하게 되었습니다.</p>
+      <p><br></p>
+      <p>많은 시간과 노력을 들여주셨음에도 아쉬운 결과를 전달드리게 되어 죄송하다는 말씀 드립니다.</p> 
+      <p><br></p>
+      <p>비록 이번 기회에는 ${applicantName}님과 함께 하지 못하지만, 향후 또 다른 기회로 만나 뵙기를 희망합니다.</p>
+      <p><br></p>
+      <p>앞으로 ${applicantName}님의 앞날에 빛나는 일만 가득하시기를 진심으로 기원합니다.</p>
+      <p><br></p>
+      <p>감사합니다.</p>`;
+  }
+};

--- a/src/constants/steps.ts
+++ b/src/constants/steps.ts
@@ -1,14 +1,14 @@
 export const signupSteps: string[] = ['이용약관동의', '회원가입', '가입성공!'];
 
-export const employSteps: string[] = ['서류지원', '서류통과', '실무면접', '채용제안'];
+export const employSteps: string[] = ['서류지원', '서류통과', '실무면접', '최종합격'];
 
 export const applySteps: string[] = ['서류지원', '서류통과', '최종합격', '전체'];
 
 export const userStatics: string[] = ['사용자 현황', '서비스 가입 현황'];
 
-export enum employStepsToEng {
-  서류지원 = 'default',
-  서류통과 = 'resume-pass',
-  실무면접 = 'interview',
-  채용제안 = 'interview-pass',
-}
+export const employStepsToEng: { [key: string]: string } = {
+  서류지원: 'default',
+  서류통과: 'resume-pass',
+  실무면접: 'interview',
+  최종합격: 'interview-pass',
+};

--- a/src/pages/applicant/ApplicantMain.tsx
+++ b/src/pages/applicant/ApplicantMain.tsx
@@ -12,7 +12,7 @@ const ApplicantMain = () => {
       <h1 id='h1'>지원 현황</h1>
       <div className='grid'>
         {applySteps.map(stepName => (
-          <StepBox key={stepName} stepName={stepName} step={step} setStep={setStep} />
+          <StepBox key={stepName} stepName={stepName} step={step} setStep={setStep} num={3} />
         ))}
       </div>
       {step === '서류통과' ? (

--- a/src/pages/company/CompanyMain.tsx
+++ b/src/pages/company/CompanyMain.tsx
@@ -3,29 +3,40 @@ import { Outlet } from 'react-router-dom';
 import styled from 'styled-components';
 import ApplicantList from '@components/mainhome/ApplicantList';
 import StepBox from '@components/mainhome/StepBox';
-import { employSteps } from '../../constants/steps';
+import { employSteps, employStepsToEng } from '../../constants/steps';
 import { useQuery } from '@tanstack/react-query';
+import { getApplications } from '@/api/companyApi';
+import Loading from '@components/common/Loading';
 
 const CompanyMain = () => {
   const [step, setStep] = useState('서류지원');
 
-  const { data, isLoading } = useQuery(['applications', step], () => {
-    // getApplications(step);
-  });
+  const { data, isLoading } = useQuery(['applications', step], getApplications);
 
+  console.log(data);
+  // console.log(employStepsToEng[step]);
+  // console.log(data[employStepsToEng[step]]);
+
+  if (isLoading) return <Loading />;
   return (
     <Container>
       <h1 id='h1'>채용 현황</h1>
       <div className='grid'>
-        {employSteps.map(stepName => (
-          <StepBox key={stepName} stepName={stepName} step={step} setStep={setStep} />
+        {employSteps.map((stepName, index) => (
+          <StepBox
+            key={stepName}
+            stepName={stepName}
+            step={step}
+            setStep={setStep}
+            num={data[employStepsToEng[stepName]]?.length}
+          />
         ))}
       </div>
 
       <div>
         <h4>{step} 리스트</h4>
-        {[1, 2, 3].map((applicant, index) => (
-          <ApplicantList key={applicant + index} index={index} step={step}></ApplicantList>
+        {data[employStepsToEng[step]].map((applicant: CompanyMainData, index: number) => (
+          <ApplicantList key={applicant.applicationId} index={index} step={step} applicant={applicant}></ApplicantList>
         ))}
       </div>
     </Container>

--- a/src/utils/getDday.ts
+++ b/src/utils/getDday.ts
@@ -1,0 +1,11 @@
+export const getDday = (dDay: string) => {
+  const today = new Date();
+  const dday = new Date(dDay);
+  let diff = today.getTime() - dday.getTime();
+  diff = Math.floor(diff / (1000 * 60 * 60 * 24));
+  if (diff > 0) {
+    return `+${diff}`;
+  } else {
+    return `${diff}`;
+  }
+};


### PR DESCRIPTION
## ✔️ 체크사항

- [x] 가장 최근 merge를 pull 받고 진행하는 것이 맞나요? 👉[최근 pr 확인 링크](https://github.com/KDT3-final-project-team2/frontend/pulls)👈
- [x] merge 하는 곳이 develop 브랜치가 맞나요?

## 🔊 팀원들에게

- 병원 메인홈 단계를 채용제안 -> 최종합격으로 변경했습니다.
- 서류지원, 실무면접단계에서는 합격/불합격 클릭시 메일 전송화면으로 이동모달 창을 띄워 먼저 안내메일을 전송하도록 유도했습니다.(메일전송 후 보내는 mailType에 따라 지원자 상태를 변경할 예정)
- 합격/불합격 버튼을 통해 메일전송시 내용 양식까지 제공, 그냥 이메일 아이콘 클릭시 받는사람과 제목만 제공
- **서류통과단계에서 면접일정확정 버튼 클릭시 지원자와 협의된 면접일자를 선택하여 캘린더 일정에 추가하는 로직을 구현할까하는데 어떠신가용..**

## 👩‍💻 담당 구역 작업

[병원 메인 홈]

- 관련 이슈 번호 #56 
- 각 단계별 지원자 목데이터 생성 및 연결
- 각 단계별 이메일 전송시 디폴트값 설정

## 🍕 담당 이외(공통 폴더/파일 포함) 작업


##  📷 결과화면(스크린샷 혹은 기능 테스트 영상)

https://user-images.githubusercontent.com/108416023/230105584-6282b0bd-d1e5-4ad0-bb88-a10184c9ad16.mp4


